### PR TITLE
[python] #278 solve boj11050

### DIFF
--- a/김민재/week11/2023.05.12/boj11050/README.md
+++ b/김민재/week11/2023.05.12/boj11050/README.md
@@ -1,0 +1,39 @@
+# [BoJ 11050 이항 계수 1](https://www.acmicpc.net/problem/11050)
+
+solved.ac Bronze I
+
+## 카테고리
+
+수학, 구현, 조합론
+
+## 시간복잡도
+
+시간복잡도는 O(1)이다.
+
+## 풀이
+
+python의 math 모듈에 있는 comb를 사용해 조합 연산을 수행했다.
+
+```python
+import sys
+from math import comb
+
+N, K = map(int, sys.stdin.readline().split())
+
+sys.stdout.write(str(comb(N, K)))
+```
+
+조합 연산을 직접 수행하면 아래와 같은 공식으로 풀어낼 수 있다. python이 아닌 다른 언어라면 factorial연산이 오버플로우를 일으킬 수 있어 위험하겠지만, python의 arbitrary precision 덕분에 오버플로우 없이 계산할 수 있다.
+
+```python
+import sys
+from math import factorial
+
+N, K = map(int, sys.stdin.readline().split())
+
+sys.stdout.write(str(factorial(N) // (factorial(K) * factorial(N - K))))
+```
+
+## 결과
+
+결과 : [맞았습니다!!](http://boj.kr/925930798dde4a3ebfd84fb63d285ed7)

--- a/김민재/week11/2023.05.12/boj11050/boj11050.py
+++ b/김민재/week11/2023.05.12/boj11050/boj11050.py
@@ -1,0 +1,6 @@
+import sys
+from math import comb
+
+N, K = map(int, sys.stdin.readline().split())
+
+sys.stdout.write(str(comb(N, K)))


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
close #278 


## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
일일 목표 달성

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
### [BoJ 11050 이항 계수 1](https://www.acmicpc.net/problem/11050)
![image](https://github.com/lawnmowing-programmer/algo/assets/33440010/47f66278-e37d-4744-a23e-bda18dfe89c2)

python의 math 모듈에 있는 comb를 사용해 조합 연산을 수행했다.

```python
import sys
from math import comb

N, K = map(int, sys.stdin.readline().split())

sys.stdout.write(str(comb(N, K)))
```

조합 연산을 직접 수행하면 아래와 같은 공식으로 풀어낼 수 있다.
python이 아닌 다른 언어라면 factorial연산이 오버플로우를 일으킬 수 있어 위험하겠지만, python의 arbitrary precision 덕분에 오버플로우 없이 계산할 수 있다.

```python
import sys
from math import factorial

N, K = map(int, sys.stdin.readline().split())

sys.stdout.write(str(factorial(N) // (factorial(K) * factorial(N - K))))
```

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
![image](https://github.com/lawnmowing-programmer/algo/assets/33440010/248758cf-4616-4f02-b20b-bd22c22b601e)


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
이항 계수는 기본적으로 조합이다. 따라서 조합을 계산하는 공식을 적용하면 되는데, 일반적인 경우 이 공식이 factorial 연산을 필요로 한다는 것이 문제가 된다. factorial 연산은 굉장히 급격히 증가하는 연산이기 때문에 그 결과가 자료형의 범위를 금방 벗어나게 되기 때문이다. 하지만 python의 arbitrary precision 덕분에 이러한 걱정 없이 공식을 적용해 O(1) 안에 해결할 수 있다.


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
